### PR TITLE
fix some issues with builds on ubuntu.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,40 @@
+# Makefile for jjclient
+
+.POSIX:
+
+CC?=		cc
+
+XMLRPC_C_FLAGS := $(shell pkg-config --cflags xmlrpc xmlrpc_client 2>/dev/null)
+XMLRPC_C_LIBS := $(shell pkg-config --libs xmlrpc xmlrpc_client 2>/dev/null)
+
+ifeq ($(XMLRPC_C_FLAGS),)
+CFLAGS+=	-I/usr/local/include -I${LOCALBASE}/include -I/usr/include
+LDFLAGS+=	-L/usr/local/lib -L${LOCALBASE}/lib -L/usr/lib/x86_64-linux-gnu
+LIBS+=		-lxmlrpc_client -lxmlrpc -lxmlrpc_util
+else
+CFLAGS+=	$(XMLRPC_C_FLAGS)
+LIBS+=		$(XMLRPC_C_LIBS)
+endif
+
+PREFIX?=	/usr/local
+MANDIR?=	${PREFIX}/share/man
+
+.PHONY: all clean install install-man
+
+all: clean jjclient
+
+jjclient: jj.o
+	${CC} ${CFLAGS} -o jjclient jj.o ${LDFLAGS} ${LIBS}
+
+jj.o: jj.c
+	${CC} ${CFLAGS} -c jj.c
+
+install: install-man
+	install -o root -g wheel -m 555 jjclient ${DESTDIR}${PREFIX}/bin/jjclient
+
+install-man:
+	install -o root -g wheel -m 444 jjclient.1 ${DESTDIR}${MANDIR}/man1/
+
+clean:
+	rm -f *.o jjclient
+

--- a/README
+++ b/README
@@ -7,8 +7,11 @@ sudo make install
 This software has been tested on MidnightBSD, FreeBSD, Linux and Mac OS X.  
 It requires xmlrpc-c to operate.
 
-On Ubuntu Linux, use 
-apt-get install -qq libxmlrpc-c3-dev
+On Ubuntu Linux, old releases needed:
+sudo apt-get install -qq libxmlrpc-c3-dev
+
+ubuntu 24.10+ needs 
+sudo apt-get install libxmlrpc-core-c3t64 libxmlrpc-core-c3-dev pkg-config
 
 To install on MidnightBSD:
 mport install jjclient
@@ -30,14 +33,17 @@ jjclient -u username -p password < myfile.txt
 
 Other flags include -s for subject and -d for turning on debug messages
 
-Compiling on MidnightBSD:
+Compiling on MidnightBSD & FreeBSD: (using bmake)
 make 
 make install
 
-NOTE: if you want to use gmake, you need to specify CC as an env var as it defaults to
-c99 which breaks.  e.g.  
-env CC=gcc12 gmake 
+NOTE: uses Makefile
 
+Compiling on Linux: (using gmake)
+make 
+make install
+
+NOTE: uses GNUmakefile
 -----
 
 A graphical client is also provided in the gtk folder.

--- a/jj.c
+++ b/jj.c
@@ -24,8 +24,8 @@ SUCH DAMAGE.
 */
 
 /* For Linux */
-#define _BSD_SOURCE
-#define  _XOPEN_SOURCE
+#define _DEFAULT_SOURCE
+#define _XOPEN_SOURCE 700
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Use _DEFAULT_SOURCE instead of _BSD_SOURCE
Use _XOPEN_SOURCE 700

Still seems to work on MidnightBSD.

Also made a GNUmakefile.  On ubuntu it's being flaky so use pkg-config there

## Summary by Sourcery

Update build configuration and source definitions for improved compatibility across different Unix-like systems

Bug Fixes:
- Replace deprecated _BSD_SOURCE with _DEFAULT_SOURCE to improve source compatibility
- Add fallback build configuration for Ubuntu using pkg-config

Enhancements:
- Upgrade XOPEN_SOURCE to version 700 for better feature support

Build:
- Create a GNUmakefile with flexible build configuration that supports pkg-config and manual library paths
- Add build configuration to support different system library locations